### PR TITLE
v1.9.x hotfix: AI 종합 진단 PDF/MD 다운로드 + Aurora SSL 타입 + 설치 스크립트

### DIFF
--- a/scripts/02-setup-nextjs.sh
+++ b/scripts/02-setup-nextjs.sh
@@ -39,6 +39,36 @@ echo -e "${CYAN}[1/3] Installing npm dependencies...${NC}"
 npm install 2>&1 | tail -3
 echo "  Node.js: $(node --version), npm: $(npm --version)"
 
+# -- [1.5/3] System packages for AI diagnosis PDF rendering -------------------
+#   PDF generation in src/lib/report-pdf.ts uses puppeteer-core + Playwright's
+#   Chromium binary. Both require system libraries and CJK fonts that are NOT
+#   present on a stock Amazon Linux 2023 AMI:
+#     - mesa-libgbm / alsa-lib / atk / at-spi2-atk / libXfixes / libXrandr /
+#       libXcomposite / libXdamage / cups-libs / pango / cairo  → Chromium runtime
+#     - google-noto-sans-cjk-kr-fonts                            → Korean text
+#     - google-noto-emoji-color-fonts                            → section icons
+#   Without these, PDF either fails to launch or renders Korean / emoji as
+#   blank glyphs (the bug fixed in v1.9.3).
+echo ""
+echo -e "${CYAN}[1.5/3] Installing PDF rendering deps (fonts + Chromium libs)...${NC}"
+sudo dnf install -y --quiet \
+    google-noto-sans-cjk-kr-fonts \
+    google-noto-emoji-color-fonts \
+    mesa-libgbm alsa-lib nspr nss libdrm libX11 libxkbcommon \
+    atk at-spi2-atk libXfixes libXrandr libXcomposite libXdamage \
+    cups-libs pango cairo 2>&1 | tail -3
+sudo fc-cache -f 2>&1 | tail -1 || true
+
+#   Install Chromium binary for Playwright if it's not already cached.
+#   The browser lives under ~/.cache/ms-playwright/ and persists across rebuilds.
+if [ ! -d "$HOME/.cache/ms-playwright" ] || ! ls "$HOME/.cache/ms-playwright" 2>/dev/null | grep -q "^chromium-"; then
+    echo "  Installing Playwright Chromium (one-time)..."
+    npx --yes playwright install chromium 2>&1 | tail -3
+else
+    echo "  Playwright Chromium: already installed ($(ls "$HOME/.cache/ms-playwright" | grep '^chromium-' | head -1))"
+fi
+echo -e "  ${GREEN}PDF deps ready${NC}"
+
 # -- [2/3] Start Steampipe as PostgreSQL service --------------------------------
 #   NOTE: PostgreSQL 별도 설치 불필요
 #   Steampipe에 PostgreSQL이 내장되어 있음 (~/.steampipe/db/)

--- a/src/app/api/report/route.ts
+++ b/src/app/api/report/route.ts
@@ -8,6 +8,7 @@ import { collectReportData, formatReportForBedrock } from '@/lib/report-generato
 import type { ReportData } from '@/lib/report-generator';
 import { REPORT_SECTIONS } from '@/lib/report-prompts';
 import { generateReportDocx } from '@/lib/report-docx';
+import { generateReportPdf } from '@/lib/report-pdf';
 import { validateAccountId, getAccountById } from '@/lib/app-config';
 import { readSchedule, writeSchedule, startScheduler, type ReportSchedule } from '@/lib/report-scheduler';
 import * as fs from 'fs';
@@ -722,9 +723,11 @@ export async function GET(request: NextRequest) {
     }
 
     try {
+      const date = new Date().toISOString().split('T')[0];
       const freshUrl = await getSignedUrl(s3Client, new GetObjectCommand({
         Bucket: getReportBucket(),
         Key: meta.s3KeyDocx,
+        ResponseContentDisposition: `attachment; filename="AWSops_Report_${date}.docx"`,
       }), { expiresIn: 60 * 60 });
 
       return NextResponse.redirect(freshUrl, 302);
@@ -759,11 +762,16 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Try S3 presigned URL first
+    // Try S3 presigned URL first — force attachment via response-content-disposition
+    // so the browser downloads instead of rendering text/markdown inline.
     if (meta.s3KeyMd) {
       try {
+        const date = new Date().toISOString().split('T')[0];
         const freshUrl = await getSignedUrl(s3Client, new GetObjectCommand({
-          Bucket: getReportBucket(), Key: meta.s3KeyMd,
+          Bucket: getReportBucket(),
+          Key: meta.s3KeyMd,
+          ResponseContentDisposition: `attachment; filename="AWSops_Report_${date}.md"`,
+          ResponseContentType: 'text/markdown; charset=utf-8',
         }), { expiresIn: 60 * 60 });
         return NextResponse.redirect(freshUrl, 302);
       } catch { /* fallback below */ }
@@ -801,6 +809,51 @@ export async function GET(request: NextRequest) {
     }
 
     return NextResponse.json({ error: 'Markdown file not available' }, { status: 500 });
+  }
+
+  // ── Download PDF (HTML → Puppeteer) ──
+  // Generated on demand from stored sections — no S3 PDF artifact yet because
+  // generation is ~2s per call. Light caching could be added if hit rate grows.
+  if (action === 'download-pdf') {
+    const meta = readReportMeta(id);
+    if (!meta) {
+      return NextResponse.json({ error: 'Report not found' }, { status: 404 });
+    }
+    if (meta.status !== 'completed') {
+      return NextResponse.json(
+        { error: 'Report not available' },
+        { status: meta.status === 'failed' ? 410 : 202 },
+      );
+    }
+    if (!meta.sections?.length) {
+      return NextResponse.json({ error: 'No sections to render' }, { status: 500 });
+    }
+
+    try {
+      const completedAt = meta.completedAt ?? meta.createdAt;
+      const isEn = (meta.scheduledBy?.startsWith('en') ?? false);
+      const pdfBuffer = await generateReportPdf({
+        title: isEn ? 'AWSops AI Diagnosis Report' : 'AWSops AI 종합진단 리포트',
+        subtitle: new Date(completedAt).toLocaleDateString(isEn ? 'en-US' : 'ko-KR', {
+          year: 'numeric', month: 'long', day: 'numeric',
+        }),
+        accountAlias: meta.accountAlias,
+        generatedAt: completedAt,
+        sections: meta.sections.map(s => ({ section: s.section, title: s.title, content: s.content })),
+      });
+      const date = new Date(completedAt).toISOString().split('T')[0];
+      return new NextResponse(new Uint8Array(pdfBuffer), {
+        headers: {
+          'Content-Type': 'application/pdf',
+          'Content-Disposition': `attachment; filename="AWSops_Report_${date}.pdf"`,
+          'Content-Length': String(pdfBuffer.length),
+        },
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error('[report] PDF generation failed:', msg);
+      return NextResponse.json({ error: 'PDF generation failed', detail: msg }, { status: 500 });
+    }
   }
 
   return NextResponse.json({ error: `Unknown action: ${action}` }, { status: 400 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,179 @@
+/**
+ * ADR-030 Phase 1: Aurora pg Pool for application state.
+ *
+ * Distinct from `steampipe.ts` — Steampipe queries AWS APIs in real time
+ * (FDW, in-memory results), while Aurora persists application state that
+ * must survive container restarts: inventory snapshots, cost snapshots,
+ * conversation memory, agentcore stats, alert diagnosis records,
+ * event-scaling plans, and report schedules.
+ *
+ * The pool is lazily initialized so existing single-host deployments
+ * without Aurora provisioned don't pay the connection cost at startup.
+ */
+import { Pool, type PoolConfig } from 'pg';
+import { readFileSync, existsSync } from 'fs';
+import type { ConnectionOptions } from 'tls';
+
+let pool: Pool | null = null;
+let initPromise: Promise<Pool> | null = null;
+
+interface AuroraCredentials {
+  host: string;
+  port: number;
+  database: string;
+  user: string;
+  password: string;
+  ssl: boolean;
+}
+
+/**
+ * Resolves Aurora connection details.
+ *
+ * Phase 1 supports two paths, evaluated in order:
+ *   1. `AURORA_DATABASE_URL` env var (DSN, e.g. postgres://user:pw@host:5432/awsops?sslmode=require)
+ *   2. Discrete env vars: AURORA_HOST, AURORA_PORT, AURORA_DB, AURORA_USER, AURORA_PASSWORD
+ *
+ * Phase 1.5 will add Secrets Manager fetch via AURORA_SECRET_ARN. For now,
+ * the deploy script (`13-deploy-aurora.sh`) reads the secret and injects
+ * the DSN into the Next.js process env.
+ */
+function resolveCredentials(): AuroraCredentials | null {
+  const dsn = process.env.AURORA_DATABASE_URL;
+  if (dsn) {
+    try {
+      const u = new URL(dsn);
+      return {
+        host: u.hostname,
+        port: u.port ? Number(u.port) : 5432,
+        database: u.pathname.replace(/^\//, '') || 'awsops',
+        user: decodeURIComponent(u.username),
+        password: decodeURIComponent(u.password),
+        ssl: (u.searchParams.get('sslmode') ?? 'require') !== 'disable',
+      };
+    } catch {
+      // Fall through to discrete env vars
+    }
+  }
+
+  const host = process.env.AURORA_HOST;
+  if (!host) return null;
+  return {
+    host,
+    port: Number(process.env.AURORA_PORT ?? '5432'),
+    database: process.env.AURORA_DB ?? 'awsops',
+    user: process.env.AURORA_USER ?? 'awsops_admin',
+    password: process.env.AURORA_PASSWORD ?? '',
+    ssl: (process.env.AURORA_SSLMODE ?? 'require') !== 'disable',
+  };
+}
+
+/**
+ * Build TLS options for the Aurora connection.
+ *
+ * Default is `rejectUnauthorized: true` — RDS is always TLS, and the in-VPC
+ * SG-only ingress doesn't excuse skipping cert verification. Use one of:
+ *   - AURORA_SSL_CA      — PEM string (full chain)
+ *   - AURORA_SSL_CA_FILE — path to a PEM file (e.g. RDS global bundle)
+ *   - AURORA_SSL_INSECURE=1 — local-dev escape hatch (logs a warning)
+ *
+ * Without an explicit CA, Node falls back to the system trust store; the
+ * RDS root chains to Amazon Trust Services which is in the default bundle.
+ * Operators are still encouraged to pin the RDS global bundle via
+ * AURORA_SSL_CA_FILE for defense in depth.
+ */
+function buildSsl(creds: AuroraCredentials): ConnectionOptions | false {
+  if (!creds.ssl) return false;
+
+  if (process.env.AURORA_SSL_INSECURE === '1') {
+    console.warn('[db] AURORA_SSL_INSECURE=1 — TLS cert verification disabled. ' +
+      'Do NOT use in production.');
+    return { rejectUnauthorized: false };
+  }
+
+  const caInline = process.env.AURORA_SSL_CA?.trim();
+  if (caInline) return { rejectUnauthorized: true, ca: caInline };
+
+  const caFile = process.env.AURORA_SSL_CA_FILE?.trim();
+  if (caFile) {
+    if (!existsSync(caFile)) {
+      throw new Error(`AURORA_SSL_CA_FILE points to a missing file: ${caFile}`);
+    }
+    return { rejectUnauthorized: true, ca: readFileSync(caFile, 'utf-8') };
+  }
+
+  // Default: verify against the system trust store. RDS global bundle chains
+  // through Amazon Trust Services, which is in the default Node bundle.
+  return { rejectUnauthorized: true };
+}
+
+function buildPoolConfig(creds: AuroraCredentials): PoolConfig {
+  return {
+    host: creds.host,
+    port: creds.port,
+    database: creds.database,
+    user: creds.user,
+    password: creds.password,
+    max: 10,
+    idleTimeoutMillis: 30_000,
+    connectionTimeoutMillis: 10_000,
+    statement_timeout: 30_000,
+    idle_in_transaction_session_timeout: 60_000,
+    ssl: buildSsl(creds),
+    application_name: 'awsops-dashboard',
+  };
+}
+
+export function isAuroraEnabled(): boolean {
+  return resolveCredentials() !== null;
+}
+
+export async function getDb(): Promise<Pool> {
+  if (pool) return pool;
+  if (initPromise) return initPromise;
+
+  initPromise = (async () => {
+    const creds = resolveCredentials();
+    if (!creds) {
+      throw new Error(
+        'Aurora not configured. Set AURORA_DATABASE_URL or AURORA_HOST/USER/PASSWORD/DB. ' +
+          'See ADR-030 and scripts/13-deploy-aurora.sh.',
+      );
+    }
+    const p = new Pool(buildPoolConfig(creds));
+    p.on('error', (err) => {
+      console.error('[db] Aurora pool error:', err.message);
+    });
+    pool = p;
+    return p;
+  })();
+
+  try {
+    return await initPromise;
+  } finally {
+    initPromise = null;
+  }
+}
+
+/**
+ * Runs SELECT 1 and reads schema_migrations.version. Returns the highest
+ * applied migration version, or throws if the schema is unreachable.
+ */
+export async function checkDbHealth(): Promise<{ ok: true; schemaVersion: number }> {
+  const db = await getDb();
+  const r = await db.query<{ version: number }>(
+    'SELECT COALESCE(MAX(version), 0)::int AS version FROM schema_migrations',
+  );
+  return { ok: true, schemaVersion: r.rows[0]?.version ?? 0 };
+}
+
+/**
+ * Closes the pool — call from a graceful shutdown hook only. The Next.js
+ * server reuses the pool across requests, so this should not run per-request.
+ */
+export async function closeDb(): Promise<void> {
+  if (pool) {
+    const p = pool;
+    pool = null;
+    await p.end();
+  }
+}

--- a/src/lib/report-pdf.ts
+++ b/src/lib/report-pdf.ts
@@ -1,0 +1,192 @@
+// AWSops AI Diagnosis Report — Server-side PDF generation via Puppeteer
+// Puppeteer를 사용한 서버사이드 PDF 생성 (사이드바 없는 순수 보고서)
+//
+// Runtime requirements (Amazon Linux 2023):
+//   sudo dnf install -y google-noto-sans-cjk-kr-fonts google-noto-emoji-fonts
+//   sudo dnf install -y mesa-libgbm alsa-lib atk at-spi2-atk \
+//                       libXfixes libXrandr libXcomposite libXdamage \
+//                       cups-libs pango cairo
+//   npx playwright install chromium      # provides the Chrome binary
+// Without the CJK font, Korean text renders as blanks.
+import puppeteer from 'puppeteer-core';
+import { marked } from 'marked';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ReportInput } from './report-pptx';
+
+function findChromePath(): string {
+  const home = process.env.HOME || '/home/ec2-user';
+  // Priority: Playwright ARM64 Chromium > Puppeteer cache
+  const candidates = [
+    // Playwright ARM64 Chromium (installed via npx playwright install chromium)
+    path.join(home, '.cache', 'ms-playwright', 'chromium-1217', 'chrome-linux', 'chrome'),
+  ];
+  // Also search for any Playwright Chromium version
+  const pwDir = path.join(home, '.cache', 'ms-playwright');
+  if (fs.existsSync(pwDir)) {
+    for (const entry of fs.readdirSync(pwDir)) {
+      if (entry.startsWith('chromium-')) {
+        candidates.push(path.join(pwDir, entry, 'chrome-linux', 'chrome'));
+      }
+    }
+  }
+  for (const p of candidates) {
+    if (fs.existsSync(p)) return p;
+  }
+  return candidates[0];
+}
+
+const CHROME_PATH = findChromePath();
+
+const SECTION_ICONS: Record<string, string> = {
+  'executive-summary': '\u{1F4CA}', 'cost-overview': '\u{1F4B0}', 'cost-compute': '\u{1F5A5}\uFE0F',
+  'cost-network': '\u{1F310}', 'cost-storage': '\u{1F4BE}', 'idle-resources': '\u{1F5D1}\uFE0F',
+  'security-posture': '\u{1F512}', 'network-architecture': '\u{1F500}', 'compute-analysis': '\u26A1',
+  'eks-analysis': '\u2638\uFE0F', 'database-analysis': '\u{1F5C4}\uFE0F', 'msk-analysis': '\u{1F4E1}',
+  'storage-analysis': '\u{1F4E6}', 'recommendations': '\u{1F3AF}', 'appendix': '\u{1F4CB}',
+};
+
+function renderSectionHtml(section: { section?: string; title: string; content: string }, index: number): string {
+  const icon = section.section ? (SECTION_ICONS[section.section] || '') : '';
+  const htmlContent = marked.parse(section.content, { gfm: true, breaks: false }) as string;
+  const pageBreak = index > 0 ? 'page-break-before: always;' : '';
+
+  return `
+    <div style="${pageBreak}">
+      <div style="display:flex; align-items:center; gap:10px; margin-top:32px; margin-bottom:12px;">
+        <span style="font-size:20px;">${icon}</span>
+        <h2 style="font-size:18px; font-weight:700; color:#111827; margin:0;">${index + 1}. ${section.title}</h2>
+      </div>
+      <div style="width:48px; height:2px; background:#2563eb; margin-bottom:16px;"></div>
+      <div class="md-content">${htmlContent}</div>
+    </div>`;
+}
+
+function buildFullHtml(input: ReportInput): string {
+  const dateStr = new Date(input.generatedAt).toLocaleDateString('ko-KR', {
+    year: 'numeric', month: 'long', day: 'numeric',
+  });
+
+  const tocItems = input.sections.map((s, i) =>
+    `<div style="display:flex; align-items:center; gap:10px; padding:3px 0;">
+      <span style="color:#9ca3af; font-family:monospace; width:24px;">${i + 1}.</span>
+      <span>${s.section ? (SECTION_ICONS[s.section] || '') : ''}</span>
+      <span style="color:#374151;">${s.title}</span>
+    </div>`
+  ).join('\n');
+
+  const sectionsHtml = input.sections.map((s, i) => renderSectionHtml(s, i)).join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<style>
+  @page { margin: 1.8cm 1.8cm 2cm 1.8cm; size: A4; }
+  * { box-sizing: border-box; }
+  body {
+    /* Noto Sans CJK KR must come BEFORE Latin sans-serif so Korean
+       text renders even when Chromium also has 'sans-serif' aliases.
+       Noto Emoji handles emoji glyphs. */
+    font-family: 'Noto Sans CJK KR', 'Noto Sans KR', -apple-system, BlinkMacSystemFont,
+                 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Emoji', sans-serif;
+    color: #1f2937; background: white; margin: 0; padding: 0;
+    line-height: 1.6; font-size: 12px;
+    word-break: keep-all;          /* avoid mid-syllable Korean breaks */
+    -webkit-print-color-adjust: exact;
+  }
+
+  /* Markdown content styles */
+  .md-content h1 { font-size: 16px; font-weight: 700; color: #111827; margin: 20px 0 8px; border-bottom: 1px solid #e5e7eb; padding-bottom: 4px; }
+  .md-content h2 { font-size: 14px; font-weight: 700; color: #1d4ed8; margin: 16px 0 8px; }
+  .md-content h3 { font-size: 13px; font-weight: 600; color: #1f2937; margin: 12px 0 6px; }
+  .md-content h4 { font-size: 13px; font-weight: 600; color: #374151; margin: 8px 0 4px; }
+  .md-content p { margin: 0 0 8px; color: #374151; line-height: 1.7; }
+  .md-content strong { color: #111827; font-weight: 600; }
+  .md-content em { color: #4b5563; }
+  .md-content code { background: #f3f4f6; color: #1d4ed8; padding: 1px 4px; border-radius: 3px; font-size: 11px; font-family: 'Fira Code', monospace; }
+  .md-content pre { background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; padding: 12px; margin: 8px 0; overflow-x: auto; font-size: 11px; }
+  .md-content pre code { background: none; color: #374151; padding: 0; }
+
+  .md-content table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 12px; }
+  .md-content thead { background: #f3f4f6; }
+  .md-content th { padding: 8px 10px; text-align: left; font-weight: 600; color: #374151; border: 1px solid #d1d5db; font-size: 11px; }
+  .md-content td { padding: 6px 10px; color: #374151; border: 1px solid #d1d5db; font-size: 11px; }
+  .md-content tr:nth-child(even) { background: #f9fafb; }
+
+  .md-content ul { list-style: disc; padding-left: 20px; margin: 4px 0 8px; }
+  .md-content ol { list-style: decimal; padding-left: 20px; margin: 4px 0 8px; }
+  .md-content li { margin: 2px 0; color: #374151; }
+  .md-content blockquote { border-left: 4px solid #60a5fa; background: #eff6ff; padding: 8px 12px; margin: 8px 0; border-radius: 0 4px 4px 0; color: #4b5563; font-style: italic; }
+  .md-content hr { border: none; border-top: 1px solid #e5e7eb; margin: 12px 0; }
+  .md-content a { color: #2563eb; text-decoration: underline; }
+</style>
+</head>
+<body>
+
+<!-- Cover -->
+<div style="padding-top:48px; margin-bottom:48px;">
+  <div style="width:64px; height:4px; background:#2563eb; margin-bottom:24px;"></div>
+  <h1 style="font-size:28px; font-weight:700; color:#111827; margin:0 0 8px;">${input.title}</h1>
+  <p style="font-size:16px; color:#2563eb; margin:0 0 4px;">AWS Infrastructure Comprehensive Analysis</p>
+  ${input.accountAlias ? `<p style="font-size:13px; color:#6b7280; margin:0 0 4px;">Account: ${input.accountAlias}</p>` : ''}
+  <p style="font-size:13px; color:#9ca3af;">${dateStr}</p>
+</div>
+
+<!-- Table of Contents -->
+<div style="page-break-before:always; margin-bottom:32px;">
+  <h2 style="font-size:18px; font-weight:700; color:#111827; border-bottom:2px solid #2563eb; padding-bottom:8px; margin-bottom:16px;">Table of Contents</h2>
+  ${tocItems}
+</div>
+
+<!-- Sections -->
+${sectionsHtml}
+
+<!-- Footer -->
+<div style="margin-top:64px; padding-top:16px; border-top:1px solid #e5e7eb; text-align:center; font-size:11px; color:#9ca3af;">
+  Generated by AWSops Dashboard
+</div>
+
+</body>
+</html>`;
+}
+
+export async function generateReportPdf(input: ReportInput): Promise<Buffer> {
+  const html = buildFullHtml(input);
+
+  const browser = await puppeteer.launch({
+    executablePath: CHROME_PATH,
+    headless: true,
+    args: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+      '--disable-gpu',
+      '--font-render-hinting=none',
+    ],
+  });
+
+  try {
+    const page = await browser.newPage();
+    await page.setContent(html, { waitUntil: 'networkidle0' });
+
+    // Use preferCSSPageSize so @page margins from the inlined stylesheet win;
+    // otherwise puppeteer's defaults override and the body padding ends up
+    // doubling the page margin.
+    const pdfUint8 = await page.pdf({
+      format: 'A4',
+      printBackground: true,
+      preferCSSPageSize: true,
+      displayHeaderFooter: true,
+      headerTemplate: '<div></div>',
+      footerTemplate: `
+        <div style="width:100%; text-align:center; font-size:9px; color:#9ca3af; padding:0 1.8cm;">
+          <span class="pageNumber"></span> / <span class="totalPages"></span>
+        </div>`,
+    });
+
+    return Buffer.from(pdfUint8);
+  } finally {
+    await browser.close();
+  }
+}

--- a/src/lib/report-pdf.ts
+++ b/src/lib/report-pdf.ts
@@ -2,7 +2,7 @@
 // Puppeteer를 사용한 서버사이드 PDF 생성 (사이드바 없는 순수 보고서)
 //
 // Runtime requirements (Amazon Linux 2023):
-//   sudo dnf install -y google-noto-sans-cjk-kr-fonts google-noto-emoji-fonts
+//   sudo dnf install -y google-noto-sans-cjk-kr-fonts google-noto-emoji-color-fonts
 //   sudo dnf install -y mesa-libgbm alsa-lib atk at-spi2-atk \
 //                       libXfixes libXrandr libXcomposite libXdamage \
 //                       cups-libs pango cairo
@@ -89,7 +89,9 @@ function buildFullHtml(input: ReportInput): string {
        text renders even when Chromium also has 'sans-serif' aliases.
        Noto Emoji handles emoji glyphs. */
     font-family: 'Noto Sans CJK KR', 'Noto Sans KR', -apple-system, BlinkMacSystemFont,
-                 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Emoji', sans-serif;
+                 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+                 'Noto Color Emoji', 'Noto Emoji', 'Apple Color Emoji',
+                 'Segoe UI Emoji', sans-serif;
     color: #1f2937; background: white; margin: 0; padding: 0;
     line-height: 1.6; font-size: 12px;
     word-break: keep-all;          /* avoid mid-syllable Korean breaks */


### PR DESCRIPTION
## Summary

Atom-oh fork에서 검증·태깅한 v1.9.1~v1.9.4 핫픽스 4건을 upstream으로 합치는 PR입니다. AI 종합 진단(`/ai-diagnosis`)의 다운로드 흐름을 정상화하고, 신규 EC2 배포 시 PDF 렌더링이 추가 수동 작업 없이 동작하도록 설치 스크립트에 의존성을 추가합니다.

`src/lib/db.ts`와 `src/lib/report-pdf.ts`는 upstream에 아직 없는 파일이라 PR이 self-contained하도록 함께 포함했습니다 (둘 다 fork 측에서 이미 머지된 PR #16, 그리고 PDF 생성 lib에서 유래).

## Commits (4)

| 태그 | 커밋 | 변경 |
|------|------|------|
| `v1.9.1` | `25033c6` | `src/lib/db.ts` — `tls.TlsOptions` → `tls.ConnectionOptions`. `@types/node` 20.19+의 `pskCallback` 시그너처 변화로 pg `PoolConfig.ssl` 할당이 깨지던 빌드 오류 수정. 런타임 동작 변화 없음. (이 파일이 upstream에 없어서 전체 파일을 신규로 포함) |
| `v1.9.2` | `5f7f256` | `src/app/api/report/route.ts` — (1) `download-pdf` 액션 핸들러 추가 (`lib/report-pdf.ts`의 Puppeteer HTML→PDF). 그동안 UI는 호출하는데 API가 400 `Unknown action`을 반환. (2) DOCX/MD S3 presign에 `ResponseContentDisposition: attachment` 추가 — MD가 새 탭에 inline 렌더되던 문제 해결. TTL은 upstream 기준 1시간 유지 |
| `v1.9.3` | `da71c05` | `src/lib/report-pdf.ts` — `font-family` 스택에 `Noto Sans CJK KR` 우선 배치 (한글 빈칸 → 정상). body padding + `@page` margin + puppeteer margin 3중 중복 제거 (`preferCSSPageSize: true`). `word-break: keep-all`로 한글 음절 중간 줄바꿈 방지. (이 파일이 upstream에 없어서 전체 파일을 신규로 포함) |
| `v1.9.4` | `21c98c6` | `font-family`에 `Noto Color Emoji` 추가 (TOC 15개 섹션 아이콘 흑백 ⊠ → 컬러). `scripts/02-setup-nextjs.sh`에 새 단계 [1.5/3] 추가: CJK + 컬러 이모지 폰트 + Chromium 시스템 라이브러리 11종(dnf, idempotent) + `npx playwright install chromium`(캐시 없을 때만) + `fc-cache -f`. 신규 EC2에서 추가 수동 작업 없이 PDF 동작 |

## 검증

운영 EC2(`awsops.atomai.click`)에서 빌드·재기동 후 다음 항목 모두 동작 확인:

- DOCX 다운로드 — 정상 (이전엔 OK였음, S3 redirect에도 filename 명시되도록 통일)
- MD 다운로드 — 새 탭 인라인 렌더 → **attachment 다운로드**로 변경 ✓
- PDF 다운로드 — 400 Unknown action → **HTTP 200, 1.5–1.7MB 유효 PDF (33쪽)** ✓
- PDF 한글 — 빈 글리프 → "AWSops AI 종합진단 리포트" / "2026년 5월 27일" 정상 렌더 ✓
- PDF 이모지 — TOC 15개 섹션 컬러 글리프 ✓
- 페이지 마진 — body padding + @page margin 중복으로 본문이 좁은 띠에 갇히던 문제 해결 ✓

## 런타임 요구사항 (Amazon Linux 2023, fresh EC2)

`scripts/02-setup-nextjs.sh`가 자동 설치하지만 참고용 명령:
```bash
sudo dnf install -y \
  google-noto-sans-cjk-kr-fonts google-noto-emoji-color-fonts \
  mesa-libgbm alsa-lib nspr nss libdrm libX11 libxkbcommon \
  atk at-spi2-atk libXfixes libXrandr libXcomposite libXdamage \
  cups-libs pango cairo
npx playwright install chromium   # ~/.cache/ms-playwright/ 에 Chrome 바이너리
```

## Test plan

- [ ] `cd web && npm install && npm run build`로 Next.js 빌드 통과 확인
- [ ] 기존 보고서가 있다면 `/ai-diagnosis`에서 DOCX/MD/PDF 모두 받아 열어 확인
- [ ] 신규 EC2에 `scripts/02-setup-nextjs.sh`를 처음 실행했을 때 fonts/Chromium 자동 설치되는지 확인 (이미 설치돼 있으면 skip)
- [ ] PDF가 한글 + 컬러 이모지 정상 렌더되는지 (대표 페이지 1~3, 마지막 페이지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)